### PR TITLE
Formula refactor

### DIFF
--- a/Formula/mint-lang.rb
+++ b/Formula/mint-lang.rb
@@ -1,9 +1,10 @@
 VERSION = "0.12.0".freeze
 
-if OS.mac?
+case
+when OS.mac?
   OS = "osx".freeze
   SHA256 = "005940ab60882824ba27faf2552db40aca76663e885fc74e5faf71538f54b9ae".freeze
-elsif OS.linux?
+when OS.linux?
   OS = "linux".freeze
   SHA256 = "d2ed33e713cbb2848540ea0f4842883a7c733f432ee5ee62e61055222757ab3e".freeze
 end
@@ -11,16 +12,22 @@ end
 class MintLang < Formula
   desc "Refreshing programming language for the front-end web"
   homepage "https://www.mint-lang.com/"
-  url "https://github.com/mint-lang/mint/releases/download/#{VERSION}/mint-#{VERSION}-#{OS}"
-  sha256 SHA256
-  head "https://github.com/mint-lang/mint.git"
 
-  depends_on "crystal"
+  stable do
+    url "https://github.com/mint-lang/mint/releases/download/#{VERSION}/mint-#{VERSION}-#{OS}"
+    sha256 SHA256
+  end
+
+  head do
+    url "https://github.com/mint-lang/mint.git"
+    depends_on "crystal" => :build
+  end
 
   def install
-    if build.stable?
+    case
+    when build.stable?
       bin.install buildpath/"mint-#{VERSION}-#{OS}" => "mint"
-    else
+    when build.head?
       system "shards", "install"
       system "shards", "build", "--error-trace", "--progress"
       bin.install "bin/mint"
@@ -28,6 +35,6 @@ class MintLang < Formula
   end
 
   test do
-    assert_match "Mint #{VERSION}", shell_output("#{bin}/mint VERSION")
+    assert_match "Mint #{VERSION}", shell_output("#{bin}/mint version")
   end
 end


### PR DESCRIPTION
- Splits the builds into `stable` and `head` blocks
- Moves `crystal` dependency into the `head` block (`brew install mint-lang --HEAD`)
- Fixes `test` block (`brew test mint-lang`)